### PR TITLE
Server generated IDs and file send consent

### DIFF
--- a/rt-share-server/server.go
+++ b/rt-share-server/server.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"crypto/tls"
 	"diesiws/server"
 	"log"
 	"net/http"
 	"time"
-	"crypto/tls"
 )
 
 func main() {

--- a/rt-share-server/server/messages.go
+++ b/rt-share-server/server/messages.go
@@ -3,37 +3,24 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-
-	"golang.org/x/net/websocket"
 )
 
 type Request struct {
-	Type    string `json:"type"`
-	Payload string `json:"payload"`
-	Text    string `json:"text"`
-	Filename    string `json:"filename"`
+	Type     string `json:"type"`
+	Payload  string `json:"payload"`
+	Text     string `json:"text"`
+	Filename string `json:"filename"`
 	Bytes    []byte `json:"bytes"`
 }
 
 type Response struct {
-	Type    string `json:"type"`
-	Status  string `json:"status"`
-	Message string `json:"message"`
-	Data    string `json:"data"`
-	Filename    string `json:"filename"`
-	Sender    string `json:"sender"`
+	Type     string `json:"type"`
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	Data     string `json:"data"`
+	Filename string `json:"filename"`
+	Sender   string `json:"sender"`
 	Bytes    []byte `json:"bytes"`
-}
-
-type AllowedSend struct {
-	Sender    string 
-	Receiver    string
-}
-
-type SendQueue struct {
-    response Response
-    sender *websocket.Conn
-    receiver *websocket.Conn
 }
 
 func (r Response) toJson() ([]byte, error) {

--- a/rt-share-server/server/server.go
+++ b/rt-share-server/server/server.go
@@ -1,100 +1,97 @@
-
 package server
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"golang.org/x/net/websocket"
-    "sync"
-    "time"
+	"sync"
+	"time"
 )
 
 type Server struct {
 	conns map[*websocket.Conn]bool
 	users map[string]*websocket.Conn
-	allowedSend map[string]string
-	sendQueue map[string]*SendQueue
-    mu         sync.RWMutex
+	mu    sync.RWMutex
 }
 
 func NewServer() *Server {
 	return &Server{
 		conns: make(map[*websocket.Conn]bool),
 		users: make(map[string]*websocket.Conn),
-        sendQueue: make(map[string]*SendQueue),
-        allowedSend: make(map[string]string),
 	}
 }
 
 func (s *Server) removeConnection(ws *websocket.Conn) {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    
-    // Skip if already removed
-    if _, exists := s.conns[ws]; !exists {
-        return
-    }
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-    // Mark as inactive but don't delete yet
-    s.conns[ws] = false
-    
-    // Find user associated with this connection
-    var userID string
-    for id, conn := range s.users {
-        if conn == ws {
-            userID = id
-            delete(s.users, id)
-            break
-        }
-    }
-    
-    // Clean up sendQueue
-    for key, sendQueue := range s.sendQueue {
-        if sendQueue.receiver == ws || sendQueue.sender == ws {
-            delete(s.sendQueue, key)
-        }
-    }
-    
-    // Close the connection
-    ws.Close()
-    
-    // Broadcast user left if needed
-    if userID != "" {
-        go s.safeBroadcast(Response{
-            Type:    "leave",
-            Status:  "userLeft",
-            Message: fmt.Sprintf("User %s left", userID),
-            Data:    userID,
-        })
-    }
+	// Skip if already removed
+	if _, exists := s.conns[ws]; !exists {
+		return
+	}
+
+	// Mark as inactive but don't delete yet
+	s.conns[ws] = false
+
+	// Find user associated with this connection
+	var userID string
+	for id, conn := range s.users {
+		if conn == ws {
+			userID = id
+			delete(s.users, id)
+			break
+		}
+	}
+
+	// Close the connection
+	ws.Close()
+
+	// Broadcast user left if needed
+	if userID != "" {
+		go s.safeBroadcast(Response{
+			Type:    "leave",
+			Status:  "userLeft",
+			Message: fmt.Sprintf("User %s left", userID),
+			Data:    userID,
+		})
+	}
 }
 
 func (s *Server) addConnection(ws *websocket.Conn) {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    s.conns[ws] = true
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conns[ws] = true
 }
 
-
 func WSHandler(s *Server) websocket.Handler {
-    return func(ws *websocket.Conn) {
-        // Check if this is a duplicate connection
-        if s.isActiveConnection(ws) {
-            fmt.Println("Duplicate connection from", ws.RemoteAddr())
-            ws.Close()
-            return
-        }
+	return func(ws *websocket.Conn) {
+		// Check if this is a duplicate connection
+		if s.isActiveConnection(ws) {
+			fmt.Println("Duplicate connection from", ws.RemoteAddr())
+			ws.Close()
+			return
+		}
 
-        fmt.Println("new incoming connection from client", ws.RemoteAddr())
-        s.addConnection(ws)
-        
-        // Set up connection tracking
-        ws.SetDeadline(time.Now().Add(5 * time.Minute))
-        
-        defer func() {
-            fmt.Println("Connection cleanup for", ws.RemoteAddr())
-            s.removeConnection(ws)
-        }()
-        
-        s.readLoop(ws)
-    }
+		fmt.Println("new incoming connection from client", ws.RemoteAddr())
+		s.addConnection(ws)
+
+		// Set up connection tracking
+		ws.SetDeadline(time.Now().Add(5 * time.Minute))
+
+		defer func() {
+			fmt.Println("Connection cleanup for", ws.RemoteAddr())
+			s.removeConnection(ws)
+		}()
+
+		s.readLoop(ws)
+	}
+}
+
+func generateID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
 }

--- a/rt-share-server/server/utils.go
+++ b/rt-share-server/server/utils.go
@@ -1,101 +1,83 @@
 package server
 
 import (
-    "encoding/json"
+	"encoding/json"
+	"fmt"
 	"golang.org/x/net/websocket"
-    "runtime/debug"
-    "fmt"
-    "time"
+	"runtime/debug"
+	"time"
 )
 
 func (s *Server) getAllUserIDsJSON() string {
-    s.mu.RLock()
-    defer s.mu.RUnlock()
-    
-    ids := make([]string, 0, len(s.users))
-    for id := range s.users {
-        ids = append(ids, id)
-    }
-    
-    jsonBytes, err := json.Marshal(ids)
-    if err != nil {
-        return "[]"
-    }
-    return string(jsonBytes)
-}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-func (s *Server) getAllowedSend(sender string) string {
-    s.mu.RLock()
-    defer s.mu.RUnlock()
-    return s.allowedSend[sender]
-}
+	ids := make([]string, 0, len(s.users))
+	for id := range s.users {
+		ids = append(ids, id)
+	}
 
-func (s *Server) setAllowedSend(sender, receiver string) {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    s.allowedSend[sender] = receiver
-}
-
-func (s *Server) clearAllowedSend(sender string) {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    delete(s.allowedSend, sender)
+	jsonBytes, err := json.Marshal(ids)
+	if err != nil {
+		return "[]"
+	}
+	return string(jsonBytes)
 }
 
 func (s *Server) getUserConn(userID string) (*websocket.Conn, bool) {
-    s.mu.RLock()
-    defer s.mu.RUnlock()
-    conn, exists := s.users[userID]
-    return conn, exists
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conn, exists := s.users[userID]
+	return conn, exists
 }
 
 func (s *Server) addUser(userID string, ws *websocket.Conn) {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    s.users[userID] = ws
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.users[userID] = ws
 }
 
 func (s *Server) getSenderUID(ws *websocket.Conn) string {
-    s.mu.RLock()
-    defer s.mu.RUnlock()
-    for id, conn := range s.users {
-        if conn == ws {
-            return id
-        }
-    }
-    return ""
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for id, conn := range s.users {
+		if conn == ws {
+			return id
+		}
+	}
+	return ""
 }
 
 func (s *Server) isActiveConnection(ws *websocket.Conn) bool {
-    s.mu.RLock()
-    defer s.mu.RUnlock()
-    return s.conns[ws]
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.conns[ws]
 }
 
 func (s *Server) safeRemoveConnection(ws *websocket.Conn) {
-    done := make(chan bool)
-    go func() {
-        defer func() {
-            if r := recover(); r != nil {
-                fmt.Printf("PANIC in removeConnection: %v\nStack:\n%s\n", 
-                    r, debug.Stack())
-            }
-        }()
-        s.removeConnection(ws)
-        close(done)
-    }()
+	done := make(chan bool)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Printf("PANIC in removeConnection: %v\nStack:\n%s\n",
+					r, debug.Stack())
+			}
+		}()
+		s.removeConnection(ws)
+		close(done)
+	}()
 
-    select {
-    case <-done:
-    case <-time.After(2 * time.Second):
-        fmt.Printf("DEADLOCK DETECTED removing connection %v\nStack:\n%s\n",
-            ws.RemoteAddr(), debug.Stack())
-    }
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		fmt.Printf("DEADLOCK DETECTED removing connection %v\nStack:\n%s\n",
+			ws.RemoteAddr(), debug.Stack())
+	}
 }
 
 func (s *Server) logState() {
-    s.mu.RLock()
-    defer s.mu.RUnlock()
-    fmt.Printf("Server state - Connections: %d, Users: %d, AllowedSends: %d, SendQueue: %d\n",
-        len(s.conns), len(s.users), len(s.allowedSend), len(s.sendQueue))
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	fmt.Printf("Server state - Connections: %d, Users: %d\n",
+		len(s.conns), len(s.users))
 }

--- a/rt-share-web/app/routes/rt-share/+component.tsx
+++ b/rt-share-web/app/routes/rt-share/+component.tsx
@@ -2,431 +2,525 @@ import { useEffect, useState, useRef } from "react";
 import type { User, Message } from "./types";
 import { Chat } from "./chat";
 import { UserList } from "./UserList";
-import { generateSessionId } from "./helpers";
 
 import "./styles.css";
 
 export function RtShare() {
-    const [sessionId, setSessionId] = useState("");
-    const wsRef = useRef<WebSocket | null>(null);
-    const peerConns = useRef<Record<string, RTCPeerConnection>>({});
-    const dataChannels = useRef<Record<string, RTCDataChannel>>({});
+  const [sessionId, setSessionId] = useState("");
+  const wsRef = useRef<WebSocket | null>(null);
+  const peerConns = useRef<Record<string, RTCPeerConnection>>({});
+  const dataChannels = useRef<Record<string, RTCDataChannel>>({});
 
-    const [users, setUsers] = useState<User[]>([]);
-    const [selectedUser, setSelectedUser] = useState<string | null>(null);
-    const selectedUserRef = useRef<string | null>(null);
-    const [messages, setMessages] = useState<Record<string, Message[]>>({});
-    const [isOnline, setIsOnline] = useState(false);
-    const [isConnecting, setIsConnecting] = useState(false);
-    const [error, setError] = useState("");
-    const [sendProgress, setSendProgress] = useState<number | null>(null);
-    const [receiveProgress, setReceiveProgress] = useState<number | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+  const [selectedUser, setSelectedUser] = useState<string | null>(null);
+  const selectedUserRef = useRef<string | null>(null);
+  const [messages, setMessages] = useState<Record<string, Message[]>>({});
+  const [isOnline, setIsOnline] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState("");
+  const [sendProgress, setSendProgress] = useState<number | null>(null);
+  const [receiveProgress, setReceiveProgress] = useState<number | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const allowedPeers = useRef<Set<string>>(new Set());
+  const pendingOutgoing = useRef<Record<string, File>>({});
 
-    useEffect(() => {
-        selectedUserRef.current = selectedUser;
-    }, [selectedUser]);
+  useEffect(() => {
+    selectedUserRef.current = selectedUser;
+  }, [selectedUser]);
 
-    // 16 KiB payloads balance throughput and memory
-    const CHUNK_SIZE = 16 * 1024;
+  // 16 KiB payloads balance throughput and memory
+  const CHUNK_SIZE = 16 * 1024;
 
-    // ────────────────────────────────────────────────────────────────────────────
-    //  Incoming-file bookkeeping
-    // ────────────────────────────────────────────────────────────────────────────
-    const incomingFiles = useRef<Record<
-        string,
-        {
-            [filename: string]: {
-                size: number;
-                received: number;
-                chunks: ArrayBuffer[];
-            };
-        }
-    >>({});
-
-    const cleanupPeerConnections = () => {
-        Object.values(dataChannels.current).forEach(ch => {
-            try { ch.close(); } catch { /* ignore */ }
-        });
-        Object.values(peerConns.current).forEach(pc => {
-            try { pc.close(); } catch { /* ignore */ }
-        });
-        peerConns.current = {};
-        dataChannels.current = {};
-    };
-
-    const selectUser = (uid: string) => {
-        setSelectedUser(uid);
-        createPeerConnection(uid, true);
-    };
-
-    useEffect(() => {
-        // Initialise session ID
-        let storedSessionId = localStorage.getItem("sessionId");
-        if (!storedSessionId) {
-            storedSessionId = generateSessionId();
-            localStorage.setItem("sessionId", storedSessionId);
-        }
-        setSessionId(storedSessionId);
-
-        // Initialise WebSocket
-        if (!wsRef.current || wsRef.current.readyState === WebSocket.CLOSED) {
-            //const socket = new WebSocket("ws://localhost:3000/");
-            const socket = new WebSocket("wss://rt-share.diesing.pro:3000/");
-            wsRef.current = socket;
-
-            setIsConnecting(true);
-
-            const connectionTimeout = setTimeout(() => {
-                if (socket.readyState !== WebSocket.OPEN) {
-                    setError("Connection timed out.");
-                    setIsConnecting(false);
-                    setTimeout(() => window.location.reload(), 3000);
-                }
-            }, 8000);
-
-            socket.onopen = () => {
-                console.log("WebSocket connection established");
-                setIsConnecting(false);
-                setIsOnline(true);
-                socket.send(JSON.stringify({ type: "join", payload: storedSessionId }) + "\n");
-            };
-
-            socket.addEventListener("error", (event) => {
-                setError("WebSocket connection error " + event);
-                setIsOnline(false);
-                setTimeout(() => window.location.reload(), 3000);
-            });
-
-            socket.onmessage = (event) => {
-                const jEvent = JSON.parse(event.data);
-                console.log("Received event:", jEvent);
-
-                if (jEvent.type === "join" && jEvent.status === "ok") {
-                    const userList: string[] = JSON.parse(jEvent.data);
-                    setUsers(userList.map(id => ({ id, isOnline: true })));
-                } else if (jEvent.type === "join" && jEvent.status === "userJoin") {
-                    const userID = jEvent.data;
-                    setUsers(prev =>
-                        prev.some(u => u.id === userID)
-                            ? prev.map(u => u.id === userID ? { ...u, isOnline: true } : u)
-                            : [...prev, { id: userID, isOnline: true }]
-                    );
-                } else if (jEvent.type === "leave" && jEvent.status === "userLeft") {
-                    const userID = jEvent.data;
-                    setUsers(prev => prev.map(u => u.id === userID ? { ...u, isOnline: false } : u));
-                } else if (jEvent.type === "offer" && jEvent.status === "forward") {
-                    handleOffer(jEvent.sender, jEvent.data);
-                } else if (jEvent.type === "answer" && jEvent.status === "forward") {
-                    handleAnswer(jEvent.sender, jEvent.data);
-                } else if (jEvent.type === "candidate" && jEvent.status === "forward") {
-                    handleCandidate(jEvent.sender, jEvent.data);
-                }
-            };
-
-            return () => {
-                cleanupPeerConnections();
-                if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-                    wsRef.current.send(JSON.stringify({ type: "leave", payload: storedSessionId }) + "\n");
-                    wsRef.current.close();
-                }
-                wsRef.current = null;
-            };
-        }
-    }, []);
-
-    const setupDataChannel = (userId: string, channel: RTCDataChannel) => {
-        channel.binaryType = "arraybuffer";
-        dataChannels.current[userId] = channel;
-
-        channel.onmessage = (e) => {
-            if (selectedUserRef.current !== userId) {
-                setSelectedUser(userId);
-            }
-            // ─────────── TEXT FRAME ───────────
-            if (typeof e.data === "string") {
-                let msg: any;
-                try { msg = JSON.parse(e.data); } catch { return; }
-
-                if (msg.type === "text") {
-                    const newMessage: Message = {
-                        id: Date.now().toString(),
-                        text: msg.text,
-                        sender: userId,
-                        timestamp: new Date(),
-                    };
-                    setMessages(prev => ({
-                        ...prev,
-                        [userId]: [...(prev[userId] || []), newMessage],
-                    }));
-                } else if (msg.type === "file-meta") {
-                    incomingFiles.current[userId] ??= {};
-                    incomingFiles.current[userId][msg.filename] = {
-                        size: msg.size,
-                        received: 0,
-                        chunks: [],
-                    };
-                    setReceiveProgress(0);
-                } else if (msg.type === "file-end") {
-                    const entry = incomingFiles.current[userId]?.[msg.filename];
-                    if (!entry) return;
-
-                    const blob = new Blob(entry.chunks);
-                    const url = URL.createObjectURL(blob);
-                    const a = Object.assign(document.createElement("a"), {
-                        href: url,
-                        download: msg.filename,
-                        style: "display:none",
-                    });
-                    document.body.appendChild(a).click();
-                    document.body.removeChild(a);
-                    URL.revokeObjectURL(url);
-
-                    const newMessage: Message = {
-                        id: Date.now().toString(),
-                        text: "",
-                        sender: userId,
-                        timestamp: new Date(),
-                        isFile: true,
-                        filename: msg.filename,
-                    };
-                    setMessages(prev => ({
-                        ...prev,
-                        [userId]: [...(prev[userId] || []), newMessage],
-                    }));
-
-                    delete incomingFiles.current[userId][msg.filename];
-                    setReceiveProgress(null);
-                }
-                return;
-            }
-
-            // ─────────── BINARY FRAME ───────────
-            if (e.data instanceof ArrayBuffer || e.data instanceof Blob) {
-                const arrayBufPromise = e.data instanceof Blob ? e.data.arrayBuffer() : Promise.resolve(e.data);
-                arrayBufPromise.then(ab => {
-                    const files = incomingFiles.current[userId];
-                    const current = files && Object.values(files)[0];
-                    if (!current) return;
-                    current.chunks.push(ab);
-                    current.received += ab.byteLength;
-                    setReceiveProgress(Math.floor((current.received / current.size) * 100));
-                });
-                return;
-            }
-
-            console.warn("Unrecognised datachannel frame:", e.data);
+  // ────────────────────────────────────────────────────────────────────────────
+  //  Incoming-file bookkeeping
+  // ────────────────────────────────────────────────────────────────────────────
+  const incomingFiles = useRef<
+    Record<
+      string,
+      {
+        [filename: string]: {
+          size: number;
+          received: number;
+          chunks: ArrayBuffer[];
         };
-    };
+      }
+    >
+  >({});
 
-    const createPeerConnection = (userId: string, initiator: boolean) => {
-        if (peerConns.current[userId]) return;
-        const pc = new RTCPeerConnection({
-            iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
-        });
-        peerConns.current[userId] = pc;
+  const cleanupPeerConnections = () => {
+    Object.values(dataChannels.current).forEach((ch) => {
+      try {
+        ch.close();
+      } catch {
+        /* ignore */
+      }
+    });
+    Object.values(peerConns.current).forEach((pc) => {
+      try {
+        pc.close();
+      } catch {
+        /* ignore */
+      }
+    });
+    peerConns.current = {};
+    dataChannels.current = {};
+  };
 
-        pc.onconnectionstatechange = () => {
-            if (pc.connectionState === "failed" || pc.connectionState === "disconnected") {
-                console.warn("Peer connection dropped", userId);
-                try { pc.close(); } catch {}
-                delete peerConns.current[userId];
-                delete dataChannels.current[userId];
-                setTimeout(() => {
-                    if (!peerConns.current[userId]) {
-                        createPeerConnection(userId, initiator);
-                    }
-                }, 1000);
-            }
-        };
+  const selectUser = (uid: string) => {
+    setSelectedUser(uid);
+    createPeerConnection(uid, true);
+  };
 
-        pc.onicecandidate = (e) => {
-            if (e.candidate && wsRef.current) {
-                wsRef.current.send(JSON.stringify({
-                    type: "candidate",
-                    payload: userId,
-                    text: JSON.stringify(e.candidate),
-                }) + "\n");
-            }
-        };
+  useEffect(() => {
+    // Initialise WebSocket and request a session ID from server
+    setSessionId("");
 
-        pc.ondatachannel = e => setupDataChannel(userId, e.channel);
+    // Initialise WebSocket
+    if (!wsRef.current || wsRef.current.readyState === WebSocket.CLOSED) {
+      //const socket = new WebSocket("ws://localhost:3000/");
+      const socket = new WebSocket("wss://rt-share.diesing.pro:3000/");
+      wsRef.current = socket;
 
-        if (initiator) {
-            const channel = pc.createDataChannel("chat");
-            setupDataChannel(userId, channel);
-            pc.createOffer()
-                .then(o => pc.setLocalDescription(o))
-                .then(() => {
-                    if (wsRef.current && pc.localDescription) {
-                        wsRef.current.send(JSON.stringify({
-                            type: "offer",
-                            payload: userId,
-                            text: JSON.stringify(pc.localDescription),
-                        }) + "\n");
-                    }
-                });
+      setIsConnecting(true);
+
+      const connectionTimeout = setTimeout(() => {
+        if (socket.readyState !== WebSocket.OPEN) {
+          setError("Connection timed out.");
+          setIsConnecting(false);
+          setTimeout(() => window.location.reload(), 3000);
         }
-    };
+      }, 8000);
 
-    const handleOffer = (userId: string, data: string) => {
-        createPeerConnection(userId, false);
-        const pc = peerConns.current[userId];
-        pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(data)))
-          .then(() => pc.createAnswer())
-          .then(a => pc.setLocalDescription(a))
-          .then(() => {
-              if (wsRef.current && pc.localDescription) {
-                  wsRef.current.send(JSON.stringify({
-                      type: "answer",
-                      payload: userId,
-                      text: JSON.stringify(pc.localDescription),
-                  }) + "\n");
-              }
-          });
-    };
+      socket.onopen = () => {
+        console.log("WebSocket connection established");
+        setIsConnecting(false);
+        setIsOnline(true);
+        socket.send(JSON.stringify({ type: "join", payload: "" }) + "\n");
+      };
 
-    const handleAnswer = (userId: string, data: string) => {
-        const pc = peerConns.current[userId];
-        if (pc) pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(data)));
-    };
+      socket.addEventListener("error", (event) => {
+        setError("WebSocket connection error " + event);
+        setIsOnline(false);
+        setTimeout(() => window.location.reload(), 3000);
+      });
 
-    const handleCandidate = (userId: string, data: string) => {
-        const pc = peerConns.current[userId];
-        if (pc) pc.addIceCandidate(new RTCIceCandidate(JSON.parse(data)));
-    };
+      socket.onmessage = (event) => {
+        const jEvent = JSON.parse(event.data);
+        console.log("Received event:", jEvent);
 
-    const handleSendMessage = (targetUser: string, text: string) => {
-        const channel = dataChannels.current[targetUser];
-        if (!channel || channel.readyState !== "open") {
-            alert("Peer connection not established yet.");
-            return;
+        if (jEvent.type === "join" && jEvent.status === "ok") {
+          const userList: string[] = JSON.parse(jEvent.data);
+          setUsers(userList.map((id) => ({ id, isOnline: true })));
+          if (!sessionId) {
+            setSessionId(jEvent.sender);
+            localStorage.setItem("sessionId", jEvent.sender);
+          }
+        } else if (jEvent.type === "join" && jEvent.status === "userJoin") {
+          const userID = jEvent.data;
+          setUsers((prev) =>
+            prev.some((u) => u.id === userID)
+              ? prev.map((u) =>
+                  u.id === userID ? { ...u, isOnline: true } : u,
+                )
+              : [...prev, { id: userID, isOnline: true }],
+          );
+        } else if (jEvent.type === "leave" && jEvent.status === "userLeft") {
+          const userID = jEvent.data;
+          setUsers((prev) =>
+            prev.map((u) => (u.id === userID ? { ...u, isOnline: false } : u)),
+          );
+        } else if (jEvent.type === "offer" && jEvent.status === "forward") {
+          handleOffer(jEvent.sender, jEvent.data);
+        } else if (jEvent.type === "answer" && jEvent.status === "forward") {
+          handleAnswer(jEvent.sender, jEvent.data);
+        } else if (jEvent.type === "candidate" && jEvent.status === "forward") {
+          handleCandidate(jEvent.sender, jEvent.data);
         }
-        channel.send(JSON.stringify({ type: "text", text }));
+      };
 
-        const newMessage: Message = {
+      return () => {
+        cleanupPeerConnections();
+        if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+          wsRef.current.send(
+            JSON.stringify({ type: "leave", payload: sessionId }) + "\n",
+          );
+          wsRef.current.close();
+        }
+        wsRef.current = null;
+      };
+    }
+  }, []);
+
+  const setupDataChannel = (userId: string, channel: RTCDataChannel) => {
+    channel.binaryType = "arraybuffer";
+    dataChannels.current[userId] = channel;
+
+    channel.onmessage = (e) => {
+      if (selectedUserRef.current !== userId) {
+        setSelectedUser(userId);
+      }
+      // ─────────── TEXT FRAME ───────────
+      if (typeof e.data === "string") {
+        let msg: any;
+        try {
+          msg = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+
+        if (msg.type === "text") {
+          const newMessage: Message = {
             id: Date.now().toString(),
-            text,
-            sender: sessionId,
+            text: msg.text,
+            sender: userId,
             timestamp: new Date(),
-        };
-        setMessages(prev => ({
+          };
+          setMessages((prev) => ({
             ...prev,
-            [targetUser]: [...(prev[targetUser] || []), newMessage],
-        }));
-    };
+            [userId]: [...(prev[userId] || []), newMessage],
+          }));
+        } else if (msg.type === "file-request") {
+          if (
+            allowedPeers.current.has(userId) ||
+            window.confirm(`${userId} wants to send ${msg.filename}. Accept?`)
+          ) {
+            allowedPeers.current.add(userId);
+            channel.send(JSON.stringify({ type: "file-accept" }));
+          } else {
+            channel.send(JSON.stringify({ type: "file-deny" }));
+          }
+        } else if (msg.type === "file-accept") {
+          const pending = pendingOutgoing.current[userId];
+          if (pending) {
+            allowedPeers.current.add(userId);
+            sendFileInternal(userId, pending);
+            delete pendingOutgoing.current[userId];
+            setStatus(null);
+          }
+        } else if (msg.type === "file-deny") {
+          delete pendingOutgoing.current[userId];
+          setStatus("File request denied");
+          setTimeout(() => setStatus(null), 2000);
+        } else if (msg.type === "file-meta") {
+          incomingFiles.current[userId] ??= {};
+          incomingFiles.current[userId][msg.filename] = {
+            size: msg.size,
+            received: 0,
+            chunks: [],
+          };
+          setReceiveProgress(0);
+        } else if (msg.type === "file-end") {
+          const entry = incomingFiles.current[userId]?.[msg.filename];
+          if (!entry) return;
 
-    // ────────────────────────────────────────────────────────────────────────────
-    //  📤  FILE TRANSFER WITH STREAMING + ROBUST BACK-PRESSURE
-    // ────────────────────────────────────────────────────────────────────────────
-    const handleSendFile = async (targetUser: string, file: File) => {
-        const channel = dataChannels.current[targetUser];
-        if (!channel || channel.readyState !== "open") {
-            alert("Peer connection not established yet.");
-            return;
-        }
+          const blob = new Blob(entry.chunks);
+          const url = URL.createObjectURL(blob);
+          const a = Object.assign(document.createElement("a"), {
+            href: url,
+            download: msg.filename,
+            style: "display:none",
+          });
+          document.body.appendChild(a).click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
 
-        console.debug(`Preparing to send '${file.name}' (${file.size} B)`);
-
-        const MAX_BUFFERED = 16 * 1024 * 1024; // 16 MiB
-        channel.bufferedAmountLowThreshold = 4 * 1024 * 1024; // 4 MiB
-
-        const waitForDrain = () =>
-            new Promise<void>(resolve => {
-                if (channel.bufferedAmount <= channel.bufferedAmountLowThreshold) {
-                    resolve();
-                    return;
-                }
-                const handler = () => {
-                    channel.removeEventListener("bufferedamountlow", handler);
-                    resolve();
-                };
-                channel.addEventListener("bufferedamountlow", handler);
-            });
-
-        // 1 — announce the file
-        channel.send(JSON.stringify({ type: "file-meta", filename: file.name, size: file.size }));
-
-        // 2 — stream and throttle
-        let sent = 0;
-        setSendProgress(0);
-
-        const reader = file.stream().getReader();
-        while (true) {
-            const { value, done } = await reader.read();
-            if (done) break;
-            let offset = 0;
-            while (offset < value.length) {
-                const end = Math.min(offset + CHUNK_SIZE, value.length);
-                const chunk = value.subarray(offset, end); // Uint8Array view
-
-                while (channel.bufferedAmount + chunk.byteLength > MAX_BUFFERED) {
-                    await waitForDrain();
-                }
-
-                try {
-                    channel.send(chunk);
-                } catch (err) {
-                    console.error("Failed to send chunk:", err);
-                    alert("File transfer aborted.");
-                    setSendProgress(null);
-                    return;
-                }
-
-                offset = end;
-                sent += chunk.byteLength;
-                setSendProgress(Math.floor((sent / file.size) * 100));
-            }
-        }
-
-        // 3 — finish
-        channel.send(JSON.stringify({ type: "file-end", filename: file.name }));
-        setSendProgress(null);
-
-        // 4 — optimistic chat entry
-        const newMessage: Message = {
+          const newMessage: Message = {
             id: Date.now().toString(),
             text: "",
-            sender: sessionId,
+            sender: userId,
             timestamp: new Date(),
             isFile: true,
-            filename: file.name,
-        };
-        setMessages(prev => ({
+            filename: msg.filename,
+          };
+          setMessages((prev) => ({
             ...prev,
-            [targetUser]: [...(prev[targetUser] || []), newMessage],
-        }));
+            [userId]: [...(prev[userId] || []), newMessage],
+          }));
+
+          delete incomingFiles.current[userId][msg.filename];
+          setReceiveProgress(null);
+        }
+        return;
+      }
+
+      // ─────────── BINARY FRAME ───────────
+      if (e.data instanceof ArrayBuffer || e.data instanceof Blob) {
+        const arrayBufPromise =
+          e.data instanceof Blob
+            ? e.data.arrayBuffer()
+            : Promise.resolve(e.data);
+        arrayBufPromise.then((ab) => {
+          const files = incomingFiles.current[userId];
+          const current = files && Object.values(files)[0];
+          if (!current) return;
+          current.chunks.push(ab);
+          current.received += ab.byteLength;
+          setReceiveProgress(
+            Math.floor((current.received / current.size) * 100),
+          );
+        });
+        return;
+      }
+
+      console.warn("Unrecognised datachannel frame:", e.data);
+    };
+  };
+
+  const createPeerConnection = (userId: string, initiator: boolean) => {
+    if (peerConns.current[userId]) return;
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+    });
+    peerConns.current[userId] = pc;
+
+    pc.onconnectionstatechange = () => {
+      if (
+        pc.connectionState === "failed" ||
+        pc.connectionState === "disconnected"
+      ) {
+        console.warn("Peer connection dropped", userId);
+        try {
+          pc.close();
+        } catch {}
+        delete peerConns.current[userId];
+        delete dataChannels.current[userId];
+        setTimeout(() => {
+          if (!peerConns.current[userId]) {
+            createPeerConnection(userId, initiator);
+          }
+        }, 1000);
+      }
     };
 
-    return (
-        <div className="rt-share-container">
-            <div className="rt-share-layout">
-                <UserList
-                    users={users}
-                    currentUser={sessionId}
-                    selectedUser={selectedUser}
-                    isOnline={isOnline}
-                    onSelect={selectUser}
-                />
-                <div className="chat-area">
-                    {isConnecting ? (
-                        <div className="loading no-chat-selected">Connecting...</div>
-                    ) : error ? (
-                        <div className="error no-chat-selected"><p>Error: {error}</p></div>
-                    ) : selectedUser ? (
-                        <Chat
-                            currentUser={sessionId}
-                            targetUser={selectedUser}
-                            messages={messages[selectedUser] || []}
-                            sendProgress={sendProgress}
-                            receiveProgress={receiveProgress}
-                            onSendMessage={text => handleSendMessage(selectedUser, text)}
-                            onSendFile={file => handleSendFile(selectedUser, file)}
-                        />
-                    ) : (
-                        <div className="no-chat-selected"><p>Select a user to start chatting</p></div>
-                    )}
-                </div>
-            </div>
-        </div>
+    pc.onicecandidate = (e) => {
+      if (e.candidate && wsRef.current) {
+        wsRef.current.send(
+          JSON.stringify({
+            type: "candidate",
+            payload: userId,
+            text: JSON.stringify(e.candidate),
+          }) + "\n",
+        );
+      }
+    };
+
+    pc.ondatachannel = (e) => setupDataChannel(userId, e.channel);
+
+    if (initiator) {
+      const channel = pc.createDataChannel("chat");
+      setupDataChannel(userId, channel);
+      pc.createOffer()
+        .then((o) => pc.setLocalDescription(o))
+        .then(() => {
+          if (wsRef.current && pc.localDescription) {
+            wsRef.current.send(
+              JSON.stringify({
+                type: "offer",
+                payload: userId,
+                text: JSON.stringify(pc.localDescription),
+              }) + "\n",
+            );
+          }
+        });
+    }
+  };
+
+  const handleOffer = (userId: string, data: string) => {
+    createPeerConnection(userId, false);
+    const pc = peerConns.current[userId];
+    pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(data)))
+      .then(() => pc.createAnswer())
+      .then((a) => pc.setLocalDescription(a))
+      .then(() => {
+        if (wsRef.current && pc.localDescription) {
+          wsRef.current.send(
+            JSON.stringify({
+              type: "answer",
+              payload: userId,
+              text: JSON.stringify(pc.localDescription),
+            }) + "\n",
+          );
+        }
+      });
+  };
+
+  const handleAnswer = (userId: string, data: string) => {
+    const pc = peerConns.current[userId];
+    if (pc)
+      pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(data)));
+  };
+
+  const handleCandidate = (userId: string, data: string) => {
+    const pc = peerConns.current[userId];
+    if (pc) pc.addIceCandidate(new RTCIceCandidate(JSON.parse(data)));
+  };
+
+  const handleSendMessage = (targetUser: string, text: string) => {
+    const channel = dataChannels.current[targetUser];
+    if (!channel || channel.readyState !== "open") {
+      alert("Peer connection not established yet.");
+      return;
+    }
+    channel.send(JSON.stringify({ type: "text", text }));
+
+    const newMessage: Message = {
+      id: Date.now().toString(),
+      text,
+      sender: sessionId,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => ({
+      ...prev,
+      [targetUser]: [...(prev[targetUser] || []), newMessage],
+    }));
+  };
+
+  // ────────────────────────────────────────────────────────────────────────────
+  //  📤  FILE TRANSFER WITH STREAMING + ROBUST BACK-PRESSURE
+  // ────────────────────────────────────────────────────────────────────────────
+  const sendFileInternal = async (targetUser: string, file: File) => {
+    const channel = dataChannels.current[targetUser];
+    if (!channel || channel.readyState !== "open") {
+      alert("Peer connection not established yet.");
+      return;
+    }
+
+    console.debug(`Preparing to send '${file.name}' (${file.size} B)`);
+
+    const MAX_BUFFERED = 16 * 1024 * 1024; // 16 MiB
+    channel.bufferedAmountLowThreshold = 4 * 1024 * 1024; // 4 MiB
+
+    const waitForDrain = () =>
+      new Promise<void>((resolve) => {
+        if (channel.bufferedAmount <= channel.bufferedAmountLowThreshold) {
+          resolve();
+          return;
+        }
+        const handler = () => {
+          channel.removeEventListener("bufferedamountlow", handler);
+          resolve();
+        };
+        channel.addEventListener("bufferedamountlow", handler);
+      });
+
+    // 1 — announce the file
+    channel.send(
+      JSON.stringify({
+        type: "file-meta",
+        filename: file.name,
+        size: file.size,
+      }),
     );
+
+    // 2 — stream and throttle
+    let sent = 0;
+    setSendProgress(0);
+
+    const reader = file.stream().getReader();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      let offset = 0;
+      while (offset < value.length) {
+        const end = Math.min(offset + CHUNK_SIZE, value.length);
+        const chunk = value.subarray(offset, end); // Uint8Array view
+
+        while (channel.bufferedAmount + chunk.byteLength > MAX_BUFFERED) {
+          await waitForDrain();
+        }
+
+        try {
+          channel.send(chunk);
+        } catch (err) {
+          console.error("Failed to send chunk:", err);
+          alert("File transfer aborted.");
+          setSendProgress(null);
+          return;
+        }
+
+        offset = end;
+        sent += chunk.byteLength;
+        setSendProgress(Math.floor((sent / file.size) * 100));
+      }
+    }
+
+    // 3 — finish
+    channel.send(JSON.stringify({ type: "file-end", filename: file.name }));
+    setSendProgress(null);
+
+    // 4 — optimistic chat entry
+    const newMessage: Message = {
+      id: Date.now().toString(),
+      text: "",
+      sender: sessionId,
+      timestamp: new Date(),
+      isFile: true,
+      filename: file.name,
+    };
+    setMessages((prev) => ({
+      ...prev,
+      [targetUser]: [...(prev[targetUser] || []), newMessage],
+    }));
+  };
+
+  const handleSendFile = async (targetUser: string, file: File) => {
+    const channel = dataChannels.current[targetUser];
+    if (!channel || channel.readyState !== "open") {
+      alert("Peer connection not established yet.");
+      return;
+    }
+
+    if (!allowedPeers.current.has(targetUser)) {
+      pendingOutgoing.current[targetUser] = file;
+      channel.send(
+        JSON.stringify({
+          type: "file-request",
+          filename: file.name,
+          size: file.size,
+        }),
+      );
+      setStatus("Waiting for acceptance...");
+      return;
+    }
+
+    await sendFileInternal(targetUser, file);
+  };
+
+  return (
+    <div className="rt-share-container">
+      <div className="rt-share-layout">
+        <UserList
+          users={users}
+          currentUser={sessionId}
+          selectedUser={selectedUser}
+          isOnline={isOnline}
+          onSelect={selectUser}
+        />
+        <div className="chat-area">
+          {isConnecting ? (
+            <div className="loading no-chat-selected">Connecting...</div>
+          ) : error ? (
+            <div className="error no-chat-selected">
+              <p>Error: {error}</p>
+            </div>
+          ) : selectedUser ? (
+            <Chat
+              currentUser={sessionId}
+              targetUser={selectedUser}
+              messages={messages[selectedUser] || []}
+              sendProgress={sendProgress}
+              receiveProgress={receiveProgress}
+              status={status}
+              onSendMessage={(text) => handleSendMessage(selectedUser, text)}
+              onSendFile={(file) => handleSendFile(selectedUser, file)}
+            />
+          ) : (
+            <div className="no-chat-selected">
+              <p>Select a user to start chatting</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/rt-share-web/app/routes/rt-share/UserList.tsx
+++ b/rt-share-web/app/routes/rt-share/UserList.tsx
@@ -8,10 +8,16 @@ interface UserListProps {
   onSelect: (id: string) => void;
 }
 
-export function UserList({ users, currentUser, selectedUser, isOnline, onSelect }: UserListProps) {
+export function UserList({
+  users,
+  currentUser,
+  selectedUser,
+  isOnline,
+  onSelect,
+}: UserListProps) {
   const heading = !isOnline
     ? "Waiting for Connection"
-    : users.filter(u => u.id !== currentUser).length === 0
+    : users.filter((u) => u.id !== currentUser).length === 0
       ? "No Users"
       : `Users (You are ${currentUser})`;
 
@@ -20,8 +26,8 @@ export function UserList({ users, currentUser, selectedUser, isOnline, onSelect 
       <h2>{heading}</h2>
       <ul>
         {users
-          .filter(u => u.id !== currentUser)
-          .map(u => (
+          .filter((u) => u.id !== currentUser)
+          .map((u) => (
             <li
               key={u.id}
               className={`${selectedUser === u.id ? "selected" : ""} ${!u.isOnline ? "offline" : ""}`}

--- a/rt-share-web/app/routes/rt-share/chat.tsx
+++ b/rt-share-web/app/routes/rt-share/chat.tsx
@@ -3,83 +3,101 @@ import { useState } from "react";
 import type { Message } from "./types";
 
 interface ChatProps {
-    currentUser: string;
-    targetUser: string;
-    messages: Message[];
-    onSendMessage: (text: string) => void;
-    onSendFile: (file: File) => void;
-    sendProgress?: number | null;
-    receiveProgress?: number | null;
+  currentUser: string;
+  targetUser: string;
+  messages: Message[];
+  onSendMessage: (text: string) => void;
+  onSendFile: (file: File) => void;
+  sendProgress?: number | null;
+  receiveProgress?: number | null;
+  status?: string | null;
 }
 
-export function Chat({ currentUser, targetUser, messages, onSendMessage, onSendFile, sendProgress = null, receiveProgress = null }: ChatProps) {
-    const [messageInput, setMessageInput] = useState("");
+export function Chat({
+  currentUser,
+  targetUser,
+  messages,
+  onSendMessage,
+  onSendFile,
+  sendProgress = null,
+  receiveProgress = null,
+  status = null,
+}: ChatProps) {
+  const [messageInput, setMessageInput] = useState("");
 
-    const handleSendMessage = () => {
-        const text = messageInput.trim();
-        if (text) {
-            console.log(text);
-            onSendMessage(text);
-            setMessageInput("");
-        }
-    };
+  const handleSendMessage = () => {
+    const text = messageInput.trim();
+    if (text) {
+      console.log(text);
+      onSendMessage(text);
+      setMessageInput("");
+    }
+  };
 
-    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (file) {
-            console.log("Sending File", file);
-            onSendFile(file);
-            e.target.value = ""; // Reset file input
-        }
-    };
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      console.log("Sending File", file);
+      onSendFile(file);
+      e.target.value = ""; // Reset file input
+    }
+  };
 
-    return (
-        <div className="chat-container">
-            <h2>Chat with {targetUser}</h2>
-            <hr />
-            {sendProgress !== null && (
-                <div className="progress-container">
-                    <div>Sending file… {sendProgress}%</div>
-                    <progress value={sendProgress} max={100}></progress>
-                </div>
-            )}
-            {receiveProgress !== null && (
-                <div className="progress-container">
-                    <div>Receiving file… {receiveProgress}%</div>
-                    <progress value={receiveProgress} max={100}></progress>
-                </div>
-            )}
-            <div className="messages">
-                {messages.map((message) => (
-                    <div
-                        key={message.id}
-                        className={`message ${message.sender === currentUser ? "sent" : "received"}`}
-                    >
-                        <div className="message-sender">
-                            {message.sender === currentUser ? "You" : message.sender}
-                        </div>
-                        {message.isFile ? (
-                            <div className="file-message">{message.filename}</div>
-                        ) : (
-                            <div className="text-message">{message.text}</div>
-                        )}
-                    </div>
-                ))}
-            </div>
-            <div className="chat-input">
-                <div className="input-container">
-                    <input
-                        type="text"
-                        value={messageInput}
-                        onChange={(e) => setMessageInput(e.target.value)}
-                        onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
-                        placeholder="Type a message..."
-                    />
-                    <button onClick={handleSendMessage}>Send</button>
-                    <label htmlFor="file" className="send-file" >Send File</label>
-                    <input type="file" name="file" id="file" onChange={handleFileChange} />
-                </div>
-            </div>
+  return (
+    <div className="chat-container">
+      <h2>Chat with {targetUser}</h2>
+      <hr />
+      {status && <div className="progress-container">{status}</div>}
+      {sendProgress !== null && (
+        <div className="progress-container">
+          <div>Sending file… {sendProgress}%</div>
+          <progress value={sendProgress} max={100}></progress>
         </div>
-    );
+      )}
+      {receiveProgress !== null && (
+        <div className="progress-container">
+          <div>Receiving file… {receiveProgress}%</div>
+          <progress value={receiveProgress} max={100}></progress>
+        </div>
+      )}
+      <div className="messages">
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={`message ${message.sender === currentUser ? "sent" : "received"}`}
+          >
+            <div className="message-sender">
+              {message.sender === currentUser ? "You" : message.sender}
+            </div>
+            {message.isFile ? (
+              <div className="file-message">{message.filename}</div>
+            ) : (
+              <div className="text-message">{message.text}</div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="chat-input">
+        <div className="input-container">
+          <input
+            type="text"
+            value={messageInput}
+            onChange={(e) => setMessageInput(e.target.value)}
+            onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
+            placeholder="Type a message..."
+          />
+          <button onClick={handleSendMessage}>Send</button>
+          <label htmlFor="file" className="send-file">
+            Send File
+          </label>
+          <input
+            type="file"
+            name="file"
+            id="file"
+            onChange={handleFileChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/rt-share-web/app/routes/rt-share/helpers.ts
+++ b/rt-share-web/app/routes/rt-share/helpers.ts
@@ -1,3 +1,0 @@
-export function generateSessionId() {
-  return Math.floor(10000 + Math.random() * 90000).toString();
-}

--- a/rt-share-web/app/routes/rt-share/styles.css
+++ b/rt-share-web/app/routes/rt-share/styles.css
@@ -1,230 +1,234 @@
 /* Base styles (mobile first) */
 body {
-    background: #ffffff;
-    color: #000000;
+  background: #ffffff;
+  color: #000000;
 }
 
 .rt-share-container {
-    padding: 10px;
-    max-width: 1200px;
-    margin: 0 auto;
-    height: 100vh;
-    overflow: hidden;
+  padding: 10px;
+  max-width: 1200px;
+  margin: 0 auto;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .rt-share-layout {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .user-list {
-    width: 100%;
-    border-right: none;
-    border-bottom: 1px solid #ccc;
-    overflow-y: auto;
-    max-height: 30vh;
-    background-color: #fff;
+  width: 100%;
+  border-right: none;
+  border-bottom: 1px solid #ccc;
+  overflow-y: auto;
+  max-height: 30vh;
+  background-color: #fff;
 }
 
 .user-list h2 {
-    padding: 15px;
-    margin: 0;
-    background: #f5f5f5;
-    border-bottom: 1px solid #ccc;
+  padding: 15px;
+  margin: 0;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ccc;
 }
 
 .user-list ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .user-list li {
-    padding: 12px 15px;
-    cursor: pointer;
-    border-bottom: 1px solid #eee;
+  padding: 12px 15px;
+  cursor: pointer;
+  border-bottom: 1px solid #eee;
 }
 
 .user-list li:hover {
-    background-color: #f0f0f0;
+  background-color: #f0f0f0;
 }
 
 .user-list li.selected {
-    background-color: #e0e0e0;
-    font-weight: bold;
+  background-color: #e0e0e0;
+  font-weight: bold;
 }
 
 .no-chat-selected {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    color: #999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #999;
 }
 
 .chat-area {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 60vh;
-    overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 60vh;
+  overflow-y: auto;
 }
 
 .chat-container {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: #fff;
 }
 
 .chat-container h2 {
-    padding: 15px;
-    margin: 0;
-    background: #f5f5f5;
-    border-bottom: 1px solid #ccc;
+  padding: 15px;
+  margin: 0;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ccc;
 }
 
 .progress-container {
-    padding: 10px;
+  padding: 10px;
 }
 
 .progress-container progress {
-    width: 100%;
+  width: 100%;
 }
 
 .messages {
-    flex: 1;
-    padding: 15px;
-    overflow-y: auto;
+  flex: 1;
+  padding: 15px;
+  overflow-y: auto;
 }
 
 .message {
-    margin-bottom: 10px;
-    padding: 8px 12px;
-    border-radius: 8px;
-    max-width: 70%;
-    word-break: break-word;
+  margin-bottom: 10px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  max-width: 70%;
+  word-break: break-word;
 }
 
 .message.sent {
-    background-color: #dcf8c6;
-    margin-left: auto;
+  background-color: #dcf8c6;
+  margin-left: auto;
 }
 
 .message.received {
-    background-color: #f1f1f1;
-    margin-right: auto;
+  background-color: #f1f1f1;
+  margin-right: auto;
 }
 
 .message-sender {
-    font-size: 0.8em;
-    color: #555;
-    margin-bottom: 4px;
+  font-size: 0.8em;
+  color: #555;
+  margin-bottom: 4px;
 }
 
 .chat-input {
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    background: #f5f5f5;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #f5f5f5;
 }
 
 .chat-input .input-container {
-    display: flex;
-    gap: 8px;
+  display: flex;
+  gap: 8px;
 }
 
 .chat-input input[type="text"] {
-    flex: 1;
-    padding: 8px;
-    font-size: 14px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+  flex: 1;
+  padding: 8px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 .chat-input button,
 .chat-input .send-file {
-    padding: 8px 12px;
-    font-size: 14px;
-    background-color: #4CAF50;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
+  padding: 8px 12px;
+  font-size: 14px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .chat-input button:hover,
 .chat-input .send-file:hover {
-    background-color: #45a049;
+  background-color: #45a049;
 }
 
 .chat-input input[type="file"] {
-    display: none;
+  display: none;
 }
 
 /* Desktop styles */
 @media (min-width: 768px) {
-    .rt-share-container {
-        padding: 20px;
-    }
+  .rt-share-container {
+    padding: 20px;
+  }
 
-    .rt-share-layout {
-        flex-direction: row;
-        height: 80vh;
-    }
+  .rt-share-layout {
+    flex-direction: row;
+    height: 80vh;
+  }
 
-    .user-list {
-        width: 250px;
-        max-height: none;
-        border-right: 1px solid #ccc;
-        border-bottom: none;
-    }
+  .user-list {
+    width: 250px;
+    max-height: none;
+    border-right: 1px solid #ccc;
+    border-bottom: none;
+  }
 
-    .chat-area {
-        min-height: auto;
-    }
+  .chat-area {
+    min-height: auto;
+  }
 
-    .chat-input {
-        padding: 15px;
-        gap: 10px;
-    }
+  .chat-input {
+    padding: 15px;
+    gap: 10px;
+  }
 
-    .chat-input .input-container {
-        gap: 10px;
-    }
+  .chat-input .input-container {
+    gap: 10px;
+  }
 }
 
 /* Loading overlay */
 .loading-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(255, 255, 255, 0.8);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(255, 255, 255, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
 }
 
 .loader {
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #3498db;
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    animation: spin 1s linear infinite;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
 }
 
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 /* 🌙 Dark mode overrides */


### PR DESCRIPTION
## Summary
- server generates session IDs and no longer tracks old file queues
- update connection handler to broadcast join with the new ID in the Sender field
- simplify utils and logging
- require peers to approve file transfers once via datachannel messages
- client requests an ID from the server and stores it
- chat UI now shows waiting/denied status

## Testing
- `go build ./...` *(fails: no route to host)*
- `npm run typecheck` *(fails: react-router not found)*