### PR TITLE
Persist user IDs and readable names

### DIFF
--- a/rt-share-server/server/handlers.go
+++ b/rt-share-server/server/handlers.go
@@ -8,11 +8,22 @@ import (
 )
 
 func (s *Server) handleJoin(r Request, ws *websocket.Conn) (Response, error) {
-	userID := r.Payload
-	if userID == "" {
-		userID = generateID()
-	}
-	s.addUser(userID, ws)
+        userID := r.Payload
+        if userID != "" {
+                if old, exists := s.getUserConn(userID); exists && old != ws {
+                        s.safeRemoveConnection(old)
+                }
+        }
+        if userID == "" {
+                for {
+                        id := generateID()
+                        if _, exists := s.getUserConn(id); !exists {
+                                userID = id
+                                break
+                        }
+                }
+        }
+        s.addUser(userID, ws)
 
 	fmt.Printf("User %s joined\n", userID)
 

--- a/rt-share-server/server/server.go
+++ b/rt-share-server/server/server.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
-	"golang.org/x/net/websocket"
-	"sync"
-	"time"
+        "crypto/rand"
+        "fmt"
+        "golang.org/x/net/websocket"
+        "math/big"
+        "sync"
+        "time"
 )
 
 type Server struct {
@@ -88,10 +88,16 @@ func WSHandler(s *Server) websocket.Handler {
 	}
 }
 
+var names = []string{"bob", "alice", "peter", "lisa", "pia"}
+
 func generateID() string {
-	b := make([]byte, 8)
-	if _, err := rand.Read(b); err != nil {
-		return fmt.Sprintf("%d", time.Now().UnixNano())
-	}
-	return hex.EncodeToString(b)
+        nameIdx, err := rand.Int(rand.Reader, big.NewInt(int64(len(names))))
+        if err != nil {
+                return fmt.Sprintf("anon-%d", time.Now().UnixNano())
+        }
+        num, err := rand.Int(rand.Reader, big.NewInt(900))
+        if err != nil {
+                return fmt.Sprintf("%s-%d", names[nameIdx.Int64()], time.Now().UnixNano()%1000)
+        }
+        return fmt.Sprintf("%s-%d", names[nameIdx.Int64()], 100+num.Int64())
 }

--- a/rt-share-web/app/routes/rt-share/+component.tsx
+++ b/rt-share-web/app/routes/rt-share/+component.tsx
@@ -73,7 +73,8 @@ export function RtShare() {
 
   useEffect(() => {
     // Initialise WebSocket and request a session ID from server
-    setSessionId("");
+    const storedId = localStorage.getItem("sessionId") || "";
+    setSessionId(storedId);
 
     // Initialise WebSocket
     if (!wsRef.current || wsRef.current.readyState === WebSocket.CLOSED) {
@@ -95,7 +96,9 @@ export function RtShare() {
         console.log("WebSocket connection established");
         setIsConnecting(false);
         setIsOnline(true);
-        socket.send(JSON.stringify({ type: "join", payload: "" }) + "\n");
+        socket.send(
+          JSON.stringify({ type: "join", payload: storedId }) + "\n",
+        );
       };
 
       socket.addEventListener("error", (event) => {


### PR DESCRIPTION
## Summary
- keep sessionId from localStorage on reload and send it on join
- generate human friendly IDs from a list of names plus random numbers
- replace old user connections when rejoining with the same ID

## Testing
- `npm run typecheck` *(fails: react-router not found)*
- `go build ./...` *(fails: unable to download toolchain due to no network)*