### PR TITLE
Implement file transfer approval with file info in progress

### DIFF
--- a/rt-share-web/app/routes/rt-share/chat.tsx
+++ b/rt-share-web/app/routes/rt-share/chat.tsx
@@ -2,17 +2,33 @@
 import { useState } from "react";
 import type { Message } from "./types";
 
+interface ProgressInfo {
+    progress: number | null;
+    filename?: string;
+    size?: number;
+}
+
 interface ChatProps {
     currentUser: string;
     targetUser: string;
     messages: Message[];
     onSendMessage: (text: string) => void;
     onSendFile: (file: File) => void;
-    sendProgress?: number | null;
-    receiveProgress?: number | null;
+    sendInfo?: ProgressInfo;
+    receiveInfo?: ProgressInfo;
 }
 
-export function Chat({ currentUser, targetUser, messages, onSendMessage, onSendFile, sendProgress = null, receiveProgress = null }: ChatProps) {
+import { formatBytes } from "./helpers";
+
+export function Chat({
+    currentUser,
+    targetUser,
+    messages,
+    onSendMessage,
+    onSendFile,
+    sendInfo = { progress: null },
+    receiveInfo = { progress: null },
+}: ChatProps) {
     const [messageInput, setMessageInput] = useState("");
 
     const handleSendMessage = () => {
@@ -37,16 +53,20 @@ export function Chat({ currentUser, targetUser, messages, onSendMessage, onSendF
         <div className="chat-container">
             <h2>Chat with {targetUser}</h2>
             <hr />
-            {sendProgress !== null && (
+            {sendInfo.progress !== null && (
                 <div className="progress-container">
-                    <div>Sending file… {sendProgress}%</div>
-                    <progress value={sendProgress} max={100}></progress>
+                    <div>
+                        Sending {sendInfo.filename} ({sendInfo.size ? formatBytes(sendInfo.size) : ""})… {sendInfo.progress}%
+                    </div>
+                    <progress value={sendInfo.progress ?? 0} max={100}></progress>
                 </div>
             )}
-            {receiveProgress !== null && (
+            {receiveInfo.progress !== null && (
                 <div className="progress-container">
-                    <div>Receiving file… {receiveProgress}%</div>
-                    <progress value={receiveProgress} max={100}></progress>
+                    <div>
+                        Receiving {receiveInfo.filename} ({receiveInfo.size ? formatBytes(receiveInfo.size) : ""})… {receiveInfo.progress}%
+                    </div>
+                    <progress value={receiveInfo.progress ?? 0} max={100}></progress>
                 </div>
             )}
             <div className="messages">

--- a/rt-share-web/app/routes/rt-share/helpers.ts
+++ b/rt-share-web/app/routes/rt-share/helpers.ts
@@ -1,3 +1,15 @@
 export function generateSessionId() {
   return Math.floor(10000 + Math.random() * 90000).toString();
 }
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let i = -1;
+  let size = bytes;
+  do {
+    size /= 1024;
+    i++;
+  } while (size >= 1024 && i < units.length - 1);
+  return `${size.toFixed(1)} ${units[i]}`;
+}


### PR DESCRIPTION
## Summary
- require receivers to explicitly accept initial file transfers via WebRTC
- remember approval so subsequent transfers skip confirmation
- show file name and human friendly size in progress display
- add utility to format byte sizes

## Testing
- `npm run typecheck` *(fails: react-router not found)*