### PR TITLE
Reduce WebRTC ICE server list and candidate pool

### DIFF
--- a/rt-share-web/app/routes/rt-share/+component.tsx
+++ b/rt-share-web/app/routes/rt-share/+component.tsx
@@ -588,27 +588,16 @@ export function RtShare() {
                 // Public STUN servers for NAT traversal
                 { urls: "stun:stun.l.google.com:19302" },
                 { urls: "stun:stun1.l.google.com:19302" },
-                { urls: "stun:stun2.l.google.com:19302" },
-                // Free public TURN servers for restrictive NATs/firewalls
-                // These allow relay connections when direct P2P fails
-                { 
-                    urls: "turn:openrelay.metered.ca:80",
-                    username: "openrelayproject",
-                    credential: "openrelayproject"
-                },
-                { 
+                // TURN server for restrictive NATs/firewalls (replace with your own for reliability)
+                // This allows relay connections when direct P2P fails.
+                {
                     urls: "turn:openrelay.metered.ca:443",
                     username: "openrelayproject",
-                    credential: "openrelayproject"
+                    credential: "openrelayproject",
                 },
-                { 
-                    urls: "turn:openrelay.metered.ca:443?transport=tcp",
-                    username: "openrelayproject",
-                    credential: "openrelayproject"
-                }
             ],
             // Improve connectivity in restrictive networks
-            iceCandidatePoolSize: 10,
+            iceCandidatePoolSize: 2,
             iceTransportPolicy: "all" // Try all connection types
         });
         peerConns.current[userId] = pc;


### PR DESCRIPTION
### Motivation
- Reduce reliance on multiple public relay/STUN entries to limit exposure to unstable public TURN servers.
- Lower the ICE candidate discovery overhead to speed up connection setup and reduce resource use.
- Encourage using a single, configurable TURN relay for reliability rather than multiple public relays.

### Description
- Trimmed the `iceServers` list to two STUN entries and a single TURN relay at `turn:openrelay.metered.ca:443`.
- Removed the extra STUN (`stun2`) and two TURN entries (`:80` and `:443?transport=tcp`).
- Reduced `iceCandidatePoolSize` from `10` to `2` to limit pre-gathered candidates.
- Kept `iceTransportPolicy: "all"` and existing connection timeout/ICE-restart logic unchanged.

### Testing
- No automated tests or CI jobs were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e3f4980e8832082a6a93b0d015104)